### PR TITLE
Added IconUrl to nupkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,4 @@ tools/**
 *.xsd.cs
 
 dist/**
+/src/Cake.Npm.Module/icon.png

--- a/build.cake
+++ b/build.cake
@@ -154,6 +154,9 @@ Task("NuGet")
 		Tags			= new[] { "cake", "build", "ci", "build", "npm", "node" },
 		OutputDirectory = artifacts + "/package",
 		Files			= content,
+		IconUrl         =  new Uri("https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png"),
+		//Icon            = "icon.png" -- see https://github.com/cake-build/cake/pull/2878
+
 		//KeepTemporaryNuSpecFile = true
 	};
 

--- a/src/Cake.Npm.Module/Cake.Npm.Module.csproj
+++ b/src/Cake.Npm.Module/Cake.Npm.Module.csproj
@@ -5,6 +5,8 @@
     <DebugType>embedded</DebugType>
     <AssemblyName>Cake.Npm.Module</AssemblyName>
     <PackageId>Cake.Npm.Module</PackageId>
+    <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
+    <PackageIcon>$(CakeContribGuidelinesIconDestinationLocation)</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added a reference to CakeContrib.Guidelines to have the currend version of the cake-contrib icon available. Sadly setting of `Icon` is currently waiting for https://github.com/cake-build/cake/pull/2878

Addresses the second half of #6  (in combination with #8 )