### PR TITLE
Proposed changes in documentation

### DIFF
--- a/docs/input/doc/cake-npm.md
+++ b/docs/input/doc/cake-npm.md
@@ -13,9 +13,6 @@ This module integrates itself into the internals of Cake meaning that tools inst
 
 Conversely, the addin is more flexible, so you can install tools only when required and have more control over when in the script you install your required npm packages. When using the module, every `#tool` is installed every time you run, regardless of whether it's needed. The addin also supports other npm commands like `pack`, `publish` and `run`, while the module only supports `install`.
 
-Finally, remember that while Cake will install addins for you (when using the `#addin` directive), modules need to be installed into the modules directory **before** the script runs. Cake can also do this for you, but it has to be "initialized" manually. Starting Cake with the `--bootstrap`-parameter will restore the modules in the `tools/Modules` folder.
-
-
 In summary:
 
 **Addin:**
@@ -32,4 +29,4 @@ In summary:
 - Integrated into Cake directly (including tool resolution)
 - Allows declaring `#tool` directives alongside other packages (i.e. NuGet, DNF, Chocolatey)
 
-Deciding whether to install your desired packages using the module or the addin will depend on your specific build requirements, your environment and how you intend to use your packages. Remember you can always get help in [the Gitter room](https://gitter.im/cake-build/cake) if you have any questions about the addin or module.
+Deciding whether to install your desired packages using the module or the addin will depend on your specific build requirements, your environment and how you intend to use your packages. Remember you can always get help at [the discussion board](https://github.com/cake-build/cake/discussions) if you have any questions about the addin or module.

--- a/docs/input/doc/examples.md
+++ b/docs/input/doc/examples.md
@@ -29,4 +29,4 @@ or to tell npm to use a SemVer-compliant range
 #tool npm:?package=sax&version=">=0.1.0 <0.2.0"
 ```
 
-Full parameter information is covered in the [parameters documentation](parameters.md).
+Full parameter information is covered in the [parameters documentation](parameters).

--- a/docs/input/doc/install.md
+++ b/docs/input/doc/install.md
@@ -12,7 +12,7 @@ Due to the fact that Cake Modules are extending and altering the internals of Ca
    ```
    #module nuget:?package=Cake.Npm.Module&version=<version>
    ```
-1. Run the build with argument `--bootstrap` (i.e. `./build.ps1 --bootrap`).
+1. For Cake versions before `1.0.0`, run the build with argument `--bootstrap` (i.e. `./build.ps1 --bootrap`).
 
    This will restore the module assembly into the `tools/Modules` folder
 1. Run the build as normal. During Cake's execution, it will recognise the module assembly which has been restored into the `tools/Modules` folder, and load it.


### PR DESCRIPTION
Fixes #73 
- Removed the scentence in cake-npm.md about bootstrap
- Replaced link to gitter in cake-npm.md with link to discussion board
- Added a hint to the bootstrap-parameter for lower Cake-versions in install.md
- Fixed link to parameters-page in examples.md