### PR TITLE
Fix documentation of 'caketools' parameter

### DIFF
--- a/docs/input/doc/parameters.md
+++ b/docs/input/doc/parameters.md
@@ -70,13 +70,13 @@ This corresponds to the `--global` option, and tells npm to install this package
 # CakeTool
 
 This parameter controls the installation location of the npm package: While the default is the current working directory (unless [global](#global) is set),
-setting `caketool` will set the installation location to inside the `tools` folder and thus ensure that the installed tools are automatically found as
+setting `caketools` will set the installation location to inside the `tools` folder and thus ensure that the installed tools are automatically found as
 tools in Cake.
 
 ### Example
 
 ```
-#tool npm:?package=yo&caketool
+#tool npm:?package=yo&caketools
 ```
 
 # Save


### PR DESCRIPTION
The parameter to install npm tools into Cake's tools directory is called 'caketools', as can be seen here 
https://github.com/cake-contrib/Cake.Npm.Module/blob/93fedbe33b7b10bed0ec92156dc6605d947afbd5/src/Cake.Npm.Module/NpmPackageInstaller.cs#L164)  

In the documentation, the parameter was called 'caketool' instead.
